### PR TITLE
Fix NPM Package name being incorrect in prereleases

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -99,7 +99,7 @@ jobs:
             To install the pre-release version, you can use the following command:
 
             ```bash
-            bun install -g cynthiaweb-mini@${{ github.ref_name }}
+            bun install -g @cynthiaweb/cynthiaweb-mini@${{ github.ref_name }}
             ```
             Note: All releases, including pre-releases, are tagged `latest` on the npm registry. Use a specific version tag if you want to install.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the installation command in pre-release workflow release notes to use the correct scoped package name for improved clarity when installing the pre-release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->